### PR TITLE
Added @ns tsconfig.js, used in snippet + example

### DIFF
--- a/.vscode/snippets.code-snippets
+++ b/.vscode/snippets.code-snippets
@@ -3,7 +3,7 @@
     "scope": "typescript",
     "prefix": "template",
     "body": [
-      "import { NS } from '../NetscriptDefinitions'",
+      "import { NS } from '@ns'",
       "",
       "export async function main(ns : NS) : Promise<void> {",
       "\t//",

--- a/src/watcher.ts
+++ b/src/watcher.ts
@@ -1,4 +1,4 @@
-import { NS, ProcessInfo } from '../NetscriptDefinitions'
+import { NS, ProcessInfo } from '@ns'
 
 export async function main(ns: NS): Promise<void> {
     const hashes: any = {}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "include": [
     "NetscriptDefinitions.d.ts",
-    "src/**/*",
+    "src/**/*", "foo.ts",
   ],
 
   "compilerOptions": {
@@ -19,7 +19,8 @@
     "baseUrl": "src/",
     "paths": {
       "/*.js": [ "*" ],
-      "*.js": [ "*" ]
+      "*.js": [ "*" ],
+      "@ns": ["../NetscriptDefinitions.d.ts"]
     }
   }
 }


### PR DESCRIPTION
I added @ns to the paths in tsconfig.json, pointing to NetscriptDefinitions.d,ts,
I  updated the watcher example, and the snippet that gets created when making a new .ts file.

This way, you don't have to constantly change the path when creating a file in a subfolder.